### PR TITLE
fix asset path.  

### DIFF
--- a/lib/tasks/tinymce-uploaddocument-assets.rake
+++ b/lib/tasks/tinymce-uploaddocument-assets.rake
@@ -4,11 +4,10 @@ Rake::Task[assets_task].enhance do
   require "tinymce/rails/asset_installer"
 
   config   = Rails.application.config
-  target   = File.join(Rails.public_path, config.assets.prefix)
+  target   = File.join(Rails.public_path, config.assets.prefix, 'tinymce/plugins')
   manifest = config.assets.manifest
 
-  assets = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__),
-    "../../app/assets/javascripts/tinymce/plugins/uploaddocument")))
+  assets = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), "../../app/assets/javascripts/tinymce/plugins/uploaddocument")))
 
   TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end


### PR DESCRIPTION
Copy the plugin.js to assets/tinymce/plugins instead of /assets.  So you end up with plugin.js in /assets/tinymce/plugins/uploaddocument instead of /assets/uploaddocument
